### PR TITLE
Create appscript and sheets integration

### DIFF
--- a/task_manager/Code.gs
+++ b/task_manager/Code.gs
@@ -1,0 +1,98 @@
+/**
+ * Task Manager App - Google Apps Script backend
+ */
+
+const SHEET_NAME = 'Tasks';
+const HEADER_ROW = ['ID', 'Task', 'Status', 'Created', 'Completed'];
+
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu('Task Manager')
+    .addItem('Open App', 'showSidebar')
+    .addItem('Setup Sheet', 'setup')
+    .addToUi();
+}
+
+function showSidebar() {
+  const html = HtmlService.createHtmlOutputFromFile('index')
+    .setTitle('Task Manager');
+  SpreadsheetApp.getUi().showSidebar(html);
+}
+
+function doGet() {
+  return HtmlService.createHtmlOutputFromFile('index')
+      .setTitle('Task Manager');
+}
+
+function include(filename) {
+  return HtmlService.createHtmlOutputFromFile(filename)
+      .getContent();
+}
+
+function setup() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(SHEET_NAME);
+  if (!sheet) {
+    sheet = ss.insertSheet(SHEET_NAME);
+  }
+  sheet.clear();
+  sheet.appendRow(HEADER_ROW);
+}
+
+function getTasks() {
+  const sheet = getSheet_();
+  const data = sheet.getDataRange().getValues();
+  const tasks = [];
+  for (let i = 1; i < data.length; i++) {
+    const [id, task, status, created, completed] = data[i];
+    tasks.push({ id, task, status, created, completed });
+  }
+  return tasks;
+}
+
+function addTask(taskText) {
+  const sheet = getSheet_();
+  const id = Utilities.getUuid();
+  const created = new Date();
+  sheet.appendRow([id, taskText, 'OPEN', created, '']);
+  return id;
+}
+
+function updateTaskStatus(id, newStatus) {
+  const sheet = getSheet_();
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][0] === id) {
+      sheet.getRange(i + 1, 3).setValue(newStatus);
+      if (newStatus === 'DONE') {
+        sheet.getRange(i + 1, 5).setValue(new Date());
+      } else {
+        sheet.getRange(i + 1, 5).setValue('');
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+function deleteTask(id) {
+  const sheet = getSheet_();
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][0] === id) {
+      sheet.deleteRow(i + 1);
+      return true;
+    }
+  }
+  return false;
+}
+
+function getSheet_() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(SHEET_NAME);
+  if (!sheet) {
+    sheet = ss.insertSheet(SHEET_NAME);
+    sheet.appendRow(HEADER_ROW);
+  }
+  return sheet;
+}

--- a/task_manager/README.md
+++ b/task_manager/README.md
@@ -1,0 +1,48 @@
+# Task Manager Google Apps Script + Sheets App
+
+## Overview
+
+Task Manager is a lightweight web application built with Google Apps Script and Google Sheets that lets you create, track, complete, and delete tasks directly inside your spreadsheet or as a standalone web app.
+
+## Features
+
+- Add new tasks with a simple form.
+- Tasks stored in a dedicated `Tasks` sheet in the active spreadsheet.
+- Mark tasks as DONE and automatically record completion time.
+- Delete tasks.
+- Access through custom spreadsheet menu or deployed web app URL.
+- Modern UI powered by Materialize CSS.
+
+## Setup Instructions
+
+1. **Create a new Google Spreadsheet** (or open an existing one).
+2. **Open the Script Editor** (`Extensions > Apps Script`).
+3. **Replace** the default files with the contents of this repository:
+   - `appsscript.json`
+   - `Code.gs`
+   - `index.html`
+   - `main.js`
+4. **Save** all files.
+5. Back in the script editor, run `setup` once to create the `Tasks` sheet.
+6. Go to `Deploy > Test deployments` or `Deploy > Manage deployments` to create a new deployment as a **Web app**.
+   - Execute as: **Me**
+   - Who has access: **Anyone**
+7. Click **Deploy** and authorize the required permissions.
+8. Share the generated web app URL with your users or open the sidebar via the custom `Task Manager` menu in the spreadsheet.
+
+## Local Development with clasp (Optional)
+
+If you prefer working locally:
+
+```bash
+npm install -g @google/clasp
+clasp login
+clasp create --title "Task Manager" --type sheets --rootDir ./task_manager
+clasp push
+```
+
+After pushing, proceed with the setup steps above.
+
+## License
+
+MIT

--- a/task_manager/appsscript.json
+++ b/task_manager/appsscript.json
@@ -1,0 +1,16 @@
+{
+  "timeZone": "America/New_York",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.scriptapp",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/userinfo.email"
+  ],
+  "webapp": {
+    "access": "ANYONE",
+    "executeAs": "USER_DEPLOYING"
+  }
+}

--- a/task_manager/index.html
+++ b/task_manager/index.html
@@ -40,8 +40,6 @@
     </table>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script>
-      <?!= include('main'); ?>
-    </script>
+    <script src="main.js"></script>
   </body>
 </html>

--- a/task_manager/index.html
+++ b/task_manager/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <title>Task Manager</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+    <style>
+      body { padding: 20px; }
+      .actions i { cursor: pointer; }
+    </style>
+  </head>
+  <body>
+    <h5>Task Manager</h5>
+
+    <div class="row">
+      <form id="addForm" class="col s12">
+        <div class="input-field col s10">
+          <input id="taskInput" type="text" required>
+          <label for="taskInput">New Task</label>
+        </div>
+        <div class="input-field col s2">
+          <button class="btn waves-effect waves-light" type="submit">
+            Add
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <table class="highlight">
+      <thead>
+        <tr>
+          <th>Task</th>
+          <th>Status</th>
+          <th>Created</th>
+          <th>Completed</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody id="tasksBody"></tbody>
+    </table>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script>
+      <?!= include('main'); ?>
+    </script>
+  </body>
+</html>

--- a/task_manager/main.js
+++ b/task_manager/main.js
@@ -1,0 +1,55 @@
+document.addEventListener('DOMContentLoaded', () => {
+  refreshTasks();
+  const form = document.getElementById('addForm');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const input = document.getElementById('taskInput');
+    const text = input.value.trim();
+    if (text) {
+      google.script.run.withSuccessHandler(() => {
+        input.value = '';
+        refreshTasks();
+      }).addTask(text);
+    }
+  });
+});
+
+function refreshTasks() {
+  google.script.run.withSuccessHandler(renderTasks).getTasks();
+}
+
+function renderTasks(tasks) {
+  const tbody = document.getElementById('tasksBody');
+  tbody.innerHTML = '';
+  tasks.forEach(t => {
+    const tr = document.createElement('tr');
+
+    tr.innerHTML = `
+      <td>${t.task}</td>
+      <td>${t.status}</td>
+      <td>${formatDate(t.created)}</td>
+      <td>${formatDate(t.completed)}</td>
+      <td class="actions">
+        <i class="material-icons green-text text-darken-2" title="Mark Done" onclick="markDone('${t.id}')">done</i>
+        <i class="material-icons red-text text-darken-2" title="Delete" onclick="deleteTask('${t.id}')">delete</i>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function markDone(id) {
+  google.script.run.withSuccessHandler(refreshTasks).updateTaskStatus(id, 'DONE');
+}
+
+function deleteTask(id) {
+  if (confirm('Delete this task?')) {
+    google.script.run.withSuccessHandler(refreshTasks).deleteTask(id);
+  }
+}
+
+function formatDate(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  return d.toLocaleDateString() + ' ' + d.toLocaleTimeString();
+}


### PR DESCRIPTION
Scaffold a Google Apps Script Task Manager app and fix client-side script loading in `index.html`.

The initial `index.html` used an incorrect server-side template directive (`<?!= include('main'); ?>`) which is not compatible with `HtmlService.createHtmlOutputFromFile`. This caused `main.js` to fail loading, rendering the app non-functional. The fix changes it to a standard `<script src="main.js"></script>` tag for proper client-side loading.